### PR TITLE
Patch framebuffer

### DIFF
--- a/OpenCore-091-debug/EFI/OC/config.plist
+++ b/OpenCore-091-debug/EFI/OC/config.plist
@@ -293,7 +293,35 @@
 			<dict>
 				<key>AAPL,ig-platform-id</key>
 				<data>
-				AACbPg==
+				BwCbPg==
+				</data>
+				<key>device-id</key>
+				<data>
+				mz4AAA==
+				</data>
+				<key>framebuffer-con0-alldata</key>
+				<data>
+				AwQIAAAEAADHAwAA
+				</data>
+				<key>framebuffer-con0-enable</key>
+				<data>
+				AQAAAA==
+				</data>
+				<key>framebuffer-con1-alldata</key>
+				<data>
+				AQEJAAAIAADHAwAA
+				</data>
+				<key>framebuffer-con1-enable</key>
+				<data>
+				AQAAAA==
+				</data>
+				<key>framebuffer-con2-alldata</key>
+				<data>
+				AgIKAAAIAADHAwAA
+				</data>
+				<key>framebuffer-con2-enable</key>
+				<data>
+				AQAAAA==
 				</data>
 				<key>framebuffer-patch-enable</key>
 				<data>


### PR DESCRIPTION
- HDMI working
- HDMI audio working
- DP max resolution not tested
- HDMI max resolution is 4k at 30 Hz (limit of UHD 630: [ref](https://ark.intel.com/content/www/us/en/ark/products/205904/intel-core-i910850k-processor-20m-cache-up-to-5-20-ghz.html))