### PR TITLE
Fix Ethernet causing KP

### DIFF
--- a/OpenCore-091-debug/EFI/OC/config.plist
+++ b/OpenCore-091-debug/EFI/OC/config.plist
@@ -281,7 +281,7 @@
 			<dict>
 				<key>device-id</key>
 				<data>
-				8hUAAA==
+				AAAAAA==
 				</data>
 			</dict>
 			<key>PciRoot(0x0)/Pci(0x1F,0x3)</key>

--- a/OpenCore-091-debug/EFI/OC/config.plist
+++ b/OpenCore-091-debug/EFI/OC/config.plist
@@ -266,7 +266,7 @@
 			<key>ResizeAppleGpuBars</key>
 			<integer>-1</integer>
 			<key>SetupVirtualMap</key>
-			<true/>
+			<false/>
 			<key>SignalAppleOS</key>
 			<false/>
 			<key>SyncRuntimePermissions</key>
@@ -988,7 +988,7 @@
 			<key>HibernateSkipsPicker</key>
 			<false/>
 			<key>HideAuxiliary</key>
-			<true/>
+			<false/>
 			<key>LauncherOption</key>
 			<string>Disabled</string>
 			<key>LauncherPath</key>
@@ -1008,7 +1008,7 @@
 			<key>TakeoffDelay</key>
 			<integer>0</integer>
 			<key>Timeout</key>
-			<integer>5</integer>
+			<integer>3</integer>
 		</dict>
 		<key>Debug</key>
 		<dict>


### PR DESCRIPTION
closes #5 

> Ok, what changed in 11.4 is the following:
> 
> * `com.apple.driver.AppleIntelI210Ethernet` no longer needs patches to work with I225 and supports it natively. So the patch should really have `MaxKernel` `20.4.0`.
> * `com.apple.DriverKit-AppleEthernetE1000` is the new DEXT driver and the default match for I225, which hangs on Gigabyte boards (works just fine on ASUS).
> * To avoid matching `com.apple.DriverKit-AppleEthernetE1000` on I225 you inject an _invalid_ `device-id` value into your LAN. instead of `F2158680` it can literally be anything, e.g. `00 00 00 00`.
> 
> Please confirm the last part. CC @khronokernel

(ref: https://github.com/dortania/bugtracker/issues/213)